### PR TITLE
Fixed File Reading and JSON Formatting in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,41 +1,35 @@
 from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
-    """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as file:
+        lines = file.readlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
     def process_file(file):
+        file = file.strip()  # 파일의 양 끝 공백 제거
         if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
+            file = file.replace('\\', '\\\\')
+        if '/' in file:
             file = file.replace('/', '\\/')
+        if '"' in file:
             file = file.replace('"', '\\"')
         return file
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
+    template = '{{"English":"{}","German":"{}"}}'
 
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template.format(process_file(english_file), process_file(german_file)))
     return processed_file_list
 
 
+
 def write_file_list(file_list: List[str], path: str) -> None:
-    """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
+
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +37,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
This pull request includes several critical fixes in 'main.py' to ensure correct file reading and JSON formatting:

1. Modified lines 5-8 in 'path_to_file_list' function:
   - Changed file open mode from 'w' to 'r' for correctly reading files.
   - Added code to read lines from the file and return them as a list.

2. Corrected and optimized 'train_file_list_to_json' function (lines 10-27):
   - Fixed escape sequence handling for backslashes and special characters.
   - Corrected the logic to process both English and German file content.
   - Updated the JSON template string to correctly format the English and German text pairs.

3. Modified lines 29-33 in 'write_file_list' function:
   - Changed file open mode to 'w' for writing the output to a file.
   - Ensured each JSON string is written on a new line for better readability and format compliance.

These changes address issues with file handling and JSON output, making the script functional as per the assignment requirements.
