### PR TITLE
path_to_file_list fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
It appears that the path_to_file_list function's file-open part have some error,
This function reads a file and returns a list of lines in the file.
So, it has to open in 'r' mode, not 'w'
so I've fixed this parts.

Please review the code and incorporate it. Thank you.