### PR TITLE
Correct errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,12 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    file = open(path, 'r')
+    lines = file.readlines()
+    for i, line in enumerate(lines):
+        if line[-1] == '\n':
+            lines[i] = line[:-1]
+    file.close()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -17,7 +22,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,16 +30,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
+            f.write(file)
             f.write('\n')
             
 if __name__ == "__main__":
@@ -43,8 +49,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
I have modified the definition of the path_to_file_list function. (Line 5)
The original code only performed the task of reading a file in 'w' mode, but this needs to be changed to 'r' mode, and there isn't even code written to return a list of lines from the file.

I changed template_start = '{"German":"' on line 20 to template_start = '{"English":"' because each line of the JSON should start with {"English".

On line 28, I corrected the mistake where german_file was written instead of english_file.

I corrected the order of concatenating the template on line 30.

I changed the 'r' mode to 'w' mode on line 36. Since it's the part where content is written to the file, it should be in write mode, not read mode.

Additionally, I rewrote the code so that instead of just adding a newline character to the file on the original line 38, the contents of the file variable are now written to the file.

Also, the functions called on lines 46 and 48 were swapped, so I corrected this.