### PR TITLE
fix some errors with main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r') #it should be changed 'r', 'lines'.
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -17,7 +17,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"' #change into English.
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,15 +25,16 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file) #we should change its name into 'german_file', because 'english_file' is already used.
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        #template_start => template_mid => template_end
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f: #open with 'w'
         for file in file_list:
             f.write('\n')
             
@@ -43,8 +44,9 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path) #changed into function 'path_to_file_list'
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    #changed into function 'train_file_list_to_json'
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list) 
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
수정 부분에는 전부 주석을 적어두었지만, 추가적으로 아래에 기술해놓겠습니다.

1-1. path_to_flie_list 함수 안에서, return으로 반환하는 변수는 lines이지만 함수 내부에서는 li라는 변수를 사용하고 있어, 올바른 작동을 위해 li 변수의 이름을 lines로 변경하였습니다.

1-2. 같은 코드 안에서, 'read'가 목적인 기능이므로 open의 옵션을 'r'로 두었습니다.


2-1. train_file_list_to_json에서, 'template_start'의 내용이 'template_mid'와 동일하게 german으로 기록되어 있어 english로 변경하였습니다.

2-2. process_file(german_file)을 받는 변수가 english_file로 되어있어, german_file로 수정하였습니다.

2-3. processed_file_list.append()안의 내용이 start=>mid=>end로 이어지도록 수정하였습니다.


3-1. write_file_list에서, 함수의 목적은 'write'이므로 open의 옵션을 'w'로 변경하였습니다.


4-1. if __main__ 안에서, german_file_list를 english_file_list와 동일하게, 위치를 읽어오는 함수인 path_to_file_list를 사용하도록 수정하였습니다.

4-2. processed_file_list는 file_list를 json으로 변형한 다음 write하는 기능을 가지고 있는 변수이므로, 기능에 알맞게 사용하는 함수를 train_file_list_to_json로 수정하였습니다.