### PR TITLE
main.py modifications

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -17,7 +17,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file+'\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
path_to_file_list modification:
- Changed li = open(path, 'w') to lines = open(path, 'r').read().split('\n')
since it should open with read authorities and also read and split by \n

train_file_list_to_json modification:
- Changed template_mid = '\",\"English\":\"' to template_mid = '\",\"German\":\"'
since the mid template should be for German
- Changed english_file = process_file(german_file) to german_file = process_file(german_file)
since the variable name was wrong
-fixed the processed_file_list.append() to processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
since the order of the templates in the string is wrong and absent

write_file_list modification:
- Changed 
with open(path, 'r') as f:
        for file in file_list:
            f.write('\n')
to 
with open(path, 'w') as f:
        for file in file_list:
            f.write(file+'\n')
Since it should open with write authority and also should write the file string in f.write

-Changed german_file_list = train_file_list_to_json(german_path) to german_file_list = path_to_file_list(german_path)
since it used the wrong function and should use path_to_file_list function instead

-Changed processed_file_list = path_to_file_list(english_file_list, german_file_list) to 
processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
since it was using the wrong function and should use train_file_list_to_json instead
