### PR TITLE
modified path_to_file_list parameter name

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'w')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
Modified path_to_file_list parameter name from li to lines because the return value  lines which should return the list of lines in the file. So the value to be returned should be lines so i changed the parameter that opens the file to 'lines'