### PR TITLE
Fix:  main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file+'\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
1. li = open(path, 'w')
-> lines = open(path, 'r').read().split('\n')
It is a function that reads a file line by line and returns as 'lines', so the variable name was changed to lines.
2.
file = file.replace('\', '\')
-> file = file.replace('\', '\\')
To change the field path to json, \ must be added, so it was modified as follows.
3.
template_start = '{"German":"'
-> template_start = '{"English":"'
Because “English” must appear in template start, the word was changed to “English.”
4.
english_file = process_file(german_file)
-> german_file = process_file(german_file)
processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
->processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
When processing german_file, the variable name was incorrectly set to english_file, so I fixed it.
Also, I modified it so that the order is correct when the English file comes after template_start(English) and the German file comes after template_mid(German) and then template_end.
5.
with open(path, 'r') as f:
->with open(path, 'w') as f:
f.write('\n')
->f.write(file+'\n')
When writing a file, you must set it to 'w' to write, and the contents stored in the file variable must also be written, so the file variable was added to the write location.
6.
german_file_list = train_file_list_to_json(german_path)
->german_file_list = path_to_file_list(german_path)
I changed the function because I need to run path_to_file_list with german_path first.
7.
processed_file_list = path_to_file_list(english_file_list, german_file_list)
-> processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
The function was changed because a processed file list must be created for each language file through the train_file_list_to_json function.