### PR TITLE
fixed path_to_file_list feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
It seems path_to_file_list is incompletely implemented.
currently this function returns nothing because there is no variable named lines.
it seems li is a typo of lines, so I fixed it to lines. 
and open(path, 'w') opens file in write mode, however we need to open in read mode and split it by lines,
I fixed it to open(path, 'r').read().split('\n').
thus, lines = open(path, 'r').read().split('\n') will be the right code.