### PR TITLE
Modified path_to_file_list feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    lines = open(path, 'r').read().split('\n')
+    return lines 
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""


### PR DESCRIPTION
1) I modified line 5 in path_to_file function
2) The file was being opened in write mode ('w') instead of read mode ('r'). This could lead to the file's contents being erased instead of read, which is not the intended behavior of the function. Also, the lines of the file were not being split correctly. The function was supposed to return a list of lines, but due to the missing line-splitting logic, it wasn't functioning as expected.
