### PR TITLE
2019311521_week12_ossp

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         german_file = process_file(german_file)
 
         processed_file_list.append(
-            template_mid + english_file + template_start + german_file + template_start)
+            template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 from typing import List
 
+
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
+
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""
@@ -27,7 +29,8 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         english_file = process_file(english_file)
         english_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(
+            template_mid + english_file + template_start + german_file + template_start)
     return processed_file_list
 
 
@@ -36,7 +39,8 @@ def write_file_list(file_list: List[str], path: str) -> None:
     with open(path, 'r') as f:
         for file in file_list:
             f.write('\n')
-            
+
+
 if __name__ == "__main__":
     path = './'
     german_path = './german.txt'
@@ -45,6 +49,7 @@ if __name__ == "__main__":
     english_file_list = path_to_file_list(english_path)
     german_file_list = train_file_list_to_json(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = path_to_file_list(
+        english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')

--- a/main.py
+++ b/main.py
@@ -47,9 +47,9 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(
+    processed_file_list = train_file_list_to_json(
         english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
         processed_file_list.append(
             template_mid + english_file + template_start + german_file + template_start)

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
     with open(path, 'r') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file+'\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
a. What line of code has been changed
- in the path_to_file_list(), I changed li to lines = open(path, 'r').read().split('\n').
- changed template_start from German to English
- changed english_file = process_file(german_file) to be german_file
- changed processed_file_list.append order to template_start + english_file + template_mid + german_file + template_end
- in the for loop of write_file_list, added file for the parameter of write
- changed german_file_list = train_file_list_to_json(german_path) to use path_to_file_list
- changed processed_file_list = path_to_file_list(english_file_list, german_file_list) to use train_file_list_to_json

b. Why it is a wrong code.
- li wasn't used nor returned, and path_to_file_list() needed to read and return the lines of given txt file.
- it is because the result order should be English, German
- english_file was being unnecessarily reallocated, while german_file wasn't being processed. That was the reason.
- the order wasn't correct, since start was for English and middle was for German
- the file was not being used. And it should writes a list of strings to a file
- the german file has to be open
- it is because the processed_file_list should have the final result, which converts two lists of file paths into a list of json strings
