### PR TITLE
modify wrong function calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
In the line 45 and 47, the function calls are wrong.
They should be on lines swapped with each other.

line 45: german_file_list = **_train_file_list_to_json_**(german_path)
     ->: german_file_list = **_path_to_file_list_**(german_path)

line 47: processed_file_list = **_path_to_file_list_**(english_file_list, german_file_list)
    ->: processed_file_list = **_train_file_list_to_json_**(english_file_list, german_file_list)

Because,
The variable `german_path` should be treated in the function `path_to_file_list`,
and the variables `english_file_list` and  `german_file_list` are the proper parameters of the function `train_file_list_to_json`