### PR TITLE
fixed 'path_to_file_list', 'train_file_list_to_json', 'write_file_list'

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    lines = open(path, 'r').read().split('\n')
+    lines = open(path, 'r').read().split("\n")
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -27,15 +27,15 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         english_file = process_file(english_file)
         english_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file+ '\n')
             
 if __name__ == "__main__":
     path = './'


### PR DESCRIPTION
line5 -> lines = open(path, 'r').read().split('\n')
line13 -> file = file.replace('\\', '\\\\')
line 20-> template_start = '{\"English\":\"'
line30 -> processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
line38 -> f.write(file+ '\n')
line46 -> german_file_list = path_to_file_list(german_path)
line48 -> processed_file_list = train_file_list_to_json(english_file_list, german_file_list)

line5: open should have 'r' for reading, not 'w'
line13: it was replacing the original string to same string
line20: both template_start and mid was german, so fixed start to english
line 30:  templates are not in order. fixed them
line 38: need to write actual file content, so added file before newline character
line46: wrong function used when reading a file. used path_to_file_list instead.
line48: wrong function used. use train_file_list_to_json to integrate two file contents and output them.
