### PR TITLE
fix sample code

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 from typing import List
 
+# Worked in collaboration with khyunjin1993:
+
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,32 +12,30 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
-
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
line5 and line 13 The variable name and function of the return value were incorrectly implemented in the 'path_to_file_list', so it was corrected.

line 20, The replacement value was incorrectly specified in 'train_file_list_to_ason', so it was corrected.
line 28, In 'train_file_list_to_jason', template_start is set to German, so it is modified to English

line 30, In 'trian_file_list_to_ason', 'temple_start', 'temple_mid', and 'temple_start' were reversed in the return value, so this was corrected.

line 36, The file is being read from 'write_file_lsit', so I modified it to 'write'. And I added a file because only the line was going into the file_list.

line 46, line 48, line 50, Instead of calling 'path_to_file_list' to create 'german_file_list' in the 'main' function, 'train_file_list' was being called, and this was corrected. And the last output file was modified because path_to_file_list was called instead of train_file_list_to_jason.