### PR TITLE
fixed multiple bugs

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
Fixed multiple bugs. (Almost renaming variables)

line 5
> `li = open(path, 'w')` to `lines = open(path, 'r').read().split('\n')`
> The function is for reading file, we should open with r mode and 


line 13
> `file = file.replace('\\', '\\')` to `file = file.replace('\\', '\\\\')`
> We should replace '\\\\' to '\\\\\\\\'

line 20

> `template_start = '{\"German\":\"'` to `template_start = '{\"English\":\"'`
> German first

line 28

> `english_file = process_file(german_file)` to `german_file = process_file(german_file)`
> renamed to german_file

line 30

> `processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)` to 
> `processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)`
> replaced code for purpose

line 36
> `with open(path, 'r') as f:` to `with open(path, 'w') as f:`
> open with w mode and write json file

line 38
> `f.write('\n')` to `f.write(file + '\n')`
> write should contain the content to write file

line 46
> `german_file_list = train_file_list_to_json(german_path)` to
> `german_file_list = path_to_file_list(german_path)`
> For open .txt file, should use path_to_file_list

line 48
> `processed_file_list = path_to_file_list(english_file_list, german_file_list)` to 
> `processed_file_list = train_file_list_to_json(english_file_list, german_file_list)`
> For writing json file, should use train_file_list_to_json



