### PR TITLE
Fix processed_file_list order and files

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,9 +25,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 


### PR DESCRIPTION
It appears that the file that was supposed to process the German file, processed the English file. Therefore I changed line 28 to make sure the German file is processed by the correct file and the English file is being processed by the correct file. Then it also appeared to be the case that the processed_file_list had the files appended in the wrong order (template_mid --> template_start --> template_start instead of template_start --> template_mid --> template_end). Therefore I changed this order in line 30.

Please review the code and incorporate it. Thank you. 