### PR TITLE
train_file_list_to_json fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,9 +25,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append('{"English":"' + english_file + '","German":"' + german_file + '"}')
     return processed_file_list
 
 


### PR DESCRIPTION
In the JSON template in the train_file_list_to_json function, you have both "German" keys. One should be "English" for the English file paths. 