### PR TITLE
fix: correct typo

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from typing import List
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
     li = open(path, 'w')
-    return lines
+    return li
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""


### PR DESCRIPTION
There's an issue on line 6.
It should return `li` defined in line 5, but it's returning `lines`, which is not defined, causing an error.