### PR TITLE
Fix: Change name of return var

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'w') # changed
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -17,7 +17,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"' # changed
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 


### PR DESCRIPTION
1.
Problem with the name of the variable that returns in the path_to_file_list function and the name of the internal variable.

Resolve by renaming internal variables

2.
The problem with "German" coming out twice

Change front to "English"