### PR TITLE
modify path_to_file_list function

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'w')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
I modify line 5 of code from `li = open(path, 'w')` to `lines = open(path, 'w')`.

The function must return 'lines' variable, but the name of a variable that must be returned is 'li' so it can't be returned.