### PR TITLE
Edited main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,9 +25,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        german_file = process_file(german_file)
+        
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 


### PR DESCRIPTION
<이전 코드>

for english_file, german_file in zip(english_file_list, german_file_list):
        english_file = process_file(english_file)
        english_file = process_file(german_file)

        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
    return processed_file_list
    
<내가 수정한 코드>
for english_file, german_file in zip(english_file_list, german_file_list):
        english_file = process_file(english_file)
        german_file = process_file(german_file)
        
        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
    return processed_file_list
    
 이 코드를 수정한 이유는 german_file을 불러와놓고는 변수명 english_file로 초기화하여 올바르게 작동하지 않고 template의 순서가 의도와 다르게 지정됐기 때문입니다.