### PR TITLE
Fix path_to_file_list w->r in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,9 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    with open(path, 'r') as file:
+        lines = file.readlines()
+    return [line.strip() for line in lines]
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""


### PR DESCRIPTION
I changed code starting 5th line
li = open(path, 'w')
return lines
to
with open(path, 'r') as file:
    lines = file.readlines()
return [line.strip() for line in lines]

it is wrong code because li is typo of lines, we need to read in this code so we should change 'w' to 'r', and we should return a list of lines in the file so we should change to lines = file.readlines(),return [line.strip() for line in lines].



