### PR TITLE
Modified write_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
             f.write('\n')
             


### PR DESCRIPTION
It appears that write_file_list has an error, so I edited line 36 in main.py.
From "with open(path, 'r') as f:" to "with open(path, 'w') as f:" because this function exists to write on file.

Thank you.