### PR TITLE
Add path_to_file_list function

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n') # developed path_to_file_list function
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
It appeared that the path_to_file_list function has not been fully developed. 
It is a wrong code because the file is opened in write mode ('w) instead of read mode ('r), which is not suitable for the context of the function. Also the variable li is declared but never used and variable lines is retuned which is not the correct syntax of python.

So I corrected the code on line 3-6 so that function  runs as it is expected.

Please review the code. Thank you.