### PR TITLE
Fixed incorrect

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,9 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+
+    # Will this be working?
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,32 +12,31 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
-    # Can this be working?
+
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
-
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +44,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
path_to_file_list 함수에서 파일 열기 모드 수정
li = open(path, 'w') -> lines = open(path, 'r').read().split('\n')
파일을 쓰기 모드('w')로 열어버리면 기존의 내용이 모두 지워집니다. 게다가 li 변수에 할당은 하였으나, 사용하지 않고 return lines라는 존재하지 않는 변수를 반환하려고 했습니다.

train_file_list_to_json 함수에서 JSON 템플릿 수정 및 파일 처리 수정
template_start = '{\"German\":\"'
template_mid = '\",\"German\":\"'
->
template_start = '{\"English\":\"'
template_mid = '\",\"German\":\"'
JSON 템플릿이 독일어만 두 번 나타나고, 영어에 대한 부분이 누락되었습니다.

write_file_list 함수에서 파일 열기 모드 수정
with open(path, 'r') as f: -> with open(path, 'w') as f:
파일을 읽기 모드('r')로 열려고 했으므로, 파일에 쓰기 작업을 할 수 없습니다.

train_file_list_to_json 함수의 로직 수정
english_file = process_file(german_file)
processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
->
english_file = process_file(english_file)
german_file = process_file(german_file)
processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
영어 파일을 처리하는 함수를 잘못 호출하고 있으며, JSON 문자열을 올바르게 생성하지 않고 있습니다.

__main__ 섹션의 함수 호출 수정
german_file_list = train_file_list_to_json(german_path)
processed_file_list = path_to_file_list(english_file_list, german_file_list)
->
english_file_list = path_to_file_list(english_path)
german_file_list = path_to_file_list(german_path)
processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
잘못된 함수 호출 순서와 인자로 인해 코드가 의도대로 동작하지 않습니다.

