### PR TITLE
fix train_file_list_to_json

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,9 +25,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 


### PR DESCRIPTION
I found three errors in the function train_file_list_to_json, so I fixed the code.

Firstly, the template for json file in the line 20 is implemented in the wrong way. 
so I changed 
template_start = '{\"German\":\"' into
template_start = '{\"English\":\"'.

Secondly, the name of the variable in the line 28 is wrong.
so I changed its name from english_file to german_file.

Finally, the order of string to append in the line 30 is wrong. 
so I changed it to correct order which is 'template_start + english_file + template_mid + german_file + template_end'.

Please review the code and incorporate it. Thank you.