### PR TITLE
Add path_to_file_list feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
I modified line 5.
It has an unmatched variable to it which must be returned, and its mode is 'w' though we need to read strings from the file.
So I made these changes in it.
First, to return the variable "lines", "li" was changed to "lines".
Second, as we have to read lines, I changed 'w' to 'r'. Then I concatenated .read().split('\n') to it to make a list of lines read from the file.