### PR TITLE
Add path_to_file_list feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
I modified the code on line 5 because the original code opened the file in write mode ('w'), which does not allow reading the contents of the file. Therefore, I changed it to open the file in read mode ('r') to enable reading the file's contents. Additionally, I changed the variable 'li' to lines to match the variable name used later in the return statement.