### PR TITLE
change_mainpy

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -25,7 +25,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
         processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
     return processed_file_list
@@ -33,7 +33,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
             f.write('\n')
             


### PR DESCRIPTION
path_to_file_list함수의 5,6line
open()함수가 쓰기 형식으로 되어있어 open(path,'r')읽기 형식으로 변경하고, 파일을 읽고 줄 별로 구분하기 위해 read().split('\n')을 추가하였습니다. 추가로 open함수 반환값을 저장하는 변수와 retrun하는 변수가 다른 오류가 있어 변수 이름을 lines로 통일하였습니다.
train_file_list_to_json함수의 27,28line
        english_file = process_file(english_file)
        english_file = process_file(german_file) 부분에서 german_file도 english_file로 저장되는 오류가 있어 
        english_file = process_file(german_file)를 german_file = process_file(german_file)로 변경하였습니다.
write_file_list함수의 36line
with open(path, 'r') as f: 부분이 쓰기 형식이 아닌 읽기 형식으로 되어있는 오류가 있어 with open(path, 'w') as f: 쓰기 형식으로 변경하였습니다.