### PR TITLE
main code edited

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    li = open(path, 'r')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -25,15 +25,15 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
             f.write('\n')
             


### PR DESCRIPTION
line 5
li = open(path, 'w')
change 'w' to 'r' because the comment instructs to 'read' a file.

line 28
change "english_file" to "german_file" bceause it is processing german_file

line 30
change
processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
to
processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
because it should match the order (start, mid, end).

line 36
change from 
"with open(path, 'r') as f:" to "with open(path, 'w') as f:"
because the comment instructs to write a list of strings to a file instead of read.