### PR TITLE
path_to_file_list changed

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,9 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    #li = open(path, 'w')
+    #return lines
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
문제: path_to_file_list 함수에서 파일을 열 때 write 모드를 사용하고 있었습니다
해결: 파일을 읽기 모드('r')로 열고, 파일의 내용을 읽어 리스트로 반환하도록 수정

In path_to_file_list function....
li = open(path, 'w')
-> lines = open(path, 'r').read().split('\n')