### PR TITLE
modify

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
             f.write('\n')
             


### PR DESCRIPTION
line 36:
with open(path, 'r') as f: -> with open(path, 'w') as f:

In the provided code, opening the file in read mode 'r' means the file is opened for reading only. In this mode, you cannot write data to the file. Therefore, if you attempt to write to the file, an error will occur. To resolve this issue, the file should be opened in write mode 'w'.