### PR TITLE
change path_to_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
일단 li=open(path,  'w') 파일을 쓰기 모드로 열고 있기 떄문에 우리의 코드에서 작동하지 않습니다. 따라서 읽기 모드인 'r'로 열어야 합니다. 또한 lines로 변수를 수정하여야합니다.  바뀐 코드가 작동하는 이유는 open(path, 'r') 파일을 읽기 모드로 열기 떄문에 파일 내용을 읽을 수 있습니다. read()는 파일의 모든 내용을 한 번에 읽은 뒤에 split('\n')를 통해 파일의 각줄을 분리합니다.