### PR TITLE
Convert path_to_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r', encoding='utf-8') as file:
+        lines = file.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
li = open(path, 'w') ->  with open(path, 'r', encoding='utf-8') as file:
				     lines = file.read().splitlines()

The original code opens the file in write mode ('w'), which means it would erase the contents of the file and open it for writing, making it impossible to read the file's contents. Therefore, the file should be opened in read mode ('r') using UTF-8 encoding, which allows reading the file's contents.
Additionally, the original code opens the file and assigns it to the variable 'li', but then attempts to return a variable 'lines'. Since 'lines' is not defined, this would cause an error. The corrected code opens the file in read mode, reads its contents into a variable 'lines', and splits the contents into a list of 'lines'. The method 'file.read()' reads the entire file as a string, and 'splitlines()' splits this string into a list of lines.