### PR TITLE
Fixed file read mode in path_to_file_list function

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as file:
+        lines = file.readlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
Corrected the file read mode in the 'path_to_file_list' function in 'main.py'.
Changed the line that opens the file, from write mode ('w') to read mode ('r').
The original code was opening the file in write mode. 
The adjustment I have made ensures the function correctly reads and returns the contents of the file.