### PR TITLE
whqhdtq12346 - Fix flaws

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n') # Modified
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\') # Modified
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"' # Modified
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file) # Modified
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end) # Modified
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f: # Modified
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n') # Modified
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path) # Modified
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list) # Modified
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
I changed line 5, 13, 20, 28, 30, 36, 38, 46, 48.
line 5 : Variable name "li" should be "lines" and it should include the file content line by line.
line 13 : '\\' should be replaced to '\\\\', because '\\' in string represents one '\'.
line 20 : template_start should be English, not German.
line 28 : Processed german_file should go to german_file, not english_file.
line 30 : Each line should compose with start + english + mid + german + end. The order is wrong.
line 36 : In write_file_list, the file path should be opened with write mode, not read-only mode.
line 38 : It writes '\n' only. It should write the each element 'file' in 'file_list' together.
line 46 : german_file_list should contain the content of a file in german_path. So, the correct function is path_to_file_list.
line 48 : processed_file_list should contain the converted json file content from english_file_list and german_file_list. So, the correct function is train_file_list_to_json.