### PR TITLE
2020311471_final_fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    lines = open(path, 'w').split('\n')
+    with open(path, 'r') as file:
+        lines = file.read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -33,7 +34,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
             f.write(file + '\n')
             

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'w').split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,9 +25,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
@@ -35,7 +35,7 @@ def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
     with open(path, 'r') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
5 li = open(path, 'w') ->
with open(path, 'r') as file:
        lines = file.read().split('\n')
return lines에 해당하는 변수가 li로 잘못 선언되어 있으며, 이를 '\n'을 기준으로 split하지 않으면 lines는  각 줄들로 이루어져 있는 리스트가 아니게 되며 글 전체가 할당됩니다.

13 file = file.replace('\\', '\\') -> file = file.replace('\\', '\\\\')
'\\'가 escape character로 작용할 수 있어 replace를 하려는 것 같은데, 이를 전혀 바꾸질 않아 고쳤습니다.

20 template_start = '{\"German\":\"' -> template_start = '{\"English\":\"'
영어를 독일어로 바꾸는 것인데 이를 유지하면 독일어를 독일어로 변환하는 것이 됩니다.

28 english_file = process_file(german_file) -> english_file = process_file(english_file)
변수명이 english_file이니 당연히 english_file에 대한 process_file 함수가 수행되어야 합니다. 애초에 밑에서 german_file에 대한 process_file 함수가 수행되니 중복됩니다.

30 processed_file_list.append(template_mid + english_file + template_start + german_file + template_start) -> processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
template_start, template_mid, template_end가 뒤섞여 있습니다.

37 with open(path, 'r') as f: -> with open(path, 'w') as f:
39번째 줄에서 f.write(file + '\n')를 수행하는데, flag가 read로 설정되어 있습니다.

38 f.write('\n') -> f.write(file + '\n')
글은 안 쓰고 개행 문자만 write하고 있습니다.

46 german_file_list = train_file_list_to_json(german_path) -> german_file_list = path_to_file_list(german_path)
48 processed_file_list = path_to_file_list(english_file_list, german_file_list) -> processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
path_to_file_list는 파일에서 text를 읽고 각 line을 list로 만드는 함수이고 train_file_list_to_json은 path_to_file_list를 통해 얻은 두 개의 list를 인수로 받아 이를 json string으로 결합하는 함수입니다. 이 과정이 뒤바뀌어 있습니다.