### PR TITLE
Add main.py modified

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    #li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -17,7 +18,8 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    # template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,9 +27,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
@@ -35,7 +37,7 @@ def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
     with open(path, 'r') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'


### PR DESCRIPTION
path_to_file_list
li = open(path, 'w')  -> lines = open(path, 'r').read().split('\n')
path_to_file_list에서는 return 을 li가 아닌 lines로 하니까 lines로 변수를 바꿔주었고, read mode로 파일을 열어야 하고 \n로 나눠줘야하기 때문에 위와같이 바꿨습니다.

train_file_list_to_json 
template_start =  '{\"German\":\"' -> template_start = '{\"English\":\"'
template_mid에 이미 German이 있고, template_start는 영어부터하는 것이 맞기 때문에 위와 같이 변경하였습니다. 

english_file = process_file(german_file) -> german_file = process_file(german_file)
german_file을 process_file을 거친 후에 english_file에 저장하는 것이 아닌 german_file에 저장하는 것이 맞기 때문에 이와 같이 변경하였습니다. 

processed_file_list.append(template_mid + english_file + template_start + german_file + template_start) -> processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
template_start, template_mid, template_end순으로 되야 맞다고 생각했기 때문에 이와 같이 변경하였습니다. 왜냐하면 template_start 다음에 english_file 이 오는데 template start는 English를 담고 있기 때문이고, template_mid 다음에 germanfile이 오는데 template_mid는 German을 담고 있습니다.

write_file_list 
f.write('\n') -> f.write(file + '\n')
for문을 돌리는데 f.write으로 단순히 줄바꿈 문자만 출력했기 때문에 file_list의 각 요소를 출력하고자 이렇게 수정하였습니다.