### PR TITLE
Fix main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,40 +2,39 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    f = open(path, 'r')
+    return f.readlines()
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
-            file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
+        file = file.rstrip("\n")
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
-def write_file_list(file_list: List[str], path: str) -> None:
+def write_string_list(string_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
-        for file in file_list:
-            f.write('\n')
+    with open(path, 'w+') as f:
+        for string in string_list:
+            f.write(f"{string}\n")
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +42,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
-    write_file_list(processed_file_list, path+'concated.json')
+    write_string_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
- `path_to_file_list` now returns a list of lines in the file specified by `path`
- `train_file_list_to_json` now properly combines list of english strings and german strings
  - Proper escaping `\` into `\\` and `"` into `\"`
  - No longer escaping `/` into `\/`
  - Fixed template ordering
  - Now strips trailing `\n` from each string
- `write_string_list` now properly writes list of string into a file, line by line
- Call proper functions with proper arguments
