### PR TITLE
Fixed the mode of path_to_file_list and defined 'lines'

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as file:
+        lines = file.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
기존의 main.py 5-6 lines에서 

li = open(path, 'w')
return lines 를

with open(path, 'r') as file:
    lines = file.read().splitlines()
return lines 로 수정

기존 코드는 파일을 쓰기 모드로 열기 때문에 내용을 읽어오지 못하여
읽기 모드로 변경하여 파일 내용을 가져오도록 수정

또한 lines 변수가 정의되지 않았기 때문에 정의하여 수정 