### PR TITLE
Fix path_to_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    li = open(path, 'r').read().split('\n')
+    return li
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""


### PR DESCRIPTION
In the original path_to_file_list function there are several mistakes. 

First, I made modification in line 5. This line is supposed to open the files correctly, instead of using command 'w', I fixed it by using 'r' and also add function to read() and split with newspace (.split('\n'))

Second, I made modification in line 6. The created variable to read file was li, so I fix the return to li instead of lines.