### PR TITLE
Fix train_list_to_json

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
         processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         english_file = process_file(english_file)
         english_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 


### PR DESCRIPTION
This branch is used to fix several mistakes in train_list_to_json. 

First, in line 28. When assigning german file, instead of assigning it into english_file, I fix it to assign it properly to german_file

Second, in line 30, template end, mid, and start is not used properly in their position, the initial position was template mid, template start, and template start. I changed it into, template start, mid, and end.