### PR TITLE
Fix write_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
There are multiple mistakes in write_file_list. I made some modifications and here are the description about my modification.

First, when assigning german_file_list in line 46, the initial code called the wrong function which is train_file_list_to_json. Instead of calling that function, I made a fix to call the proper function which is path_to_file_list (function to get the list of lines from german files)

Second, in line 48, with similar mistakes, proccessed_file_list called the wrong function which is path_to_file_list. Instead of calling that function, I made a fix to call the proper function which is train_file_list_to_json (function to convert two list of file paths into a list of json strings)