### PR TITLE
change path_to_file_list, train_file_list_to_json

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,49 +2,41 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    with open(path, 'r') as file:
+        lines = file.readlines()
+        return [line.strip() for line in lines]
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""
     # Preprocess unwanted characters
     def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
+        file = file.replace('\\', '\\\\').replace('/', '\\/').replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
+    template = '{{"English":"{}", "German":"{}"}}'
 
-    # Can this be working?
-    processed_file_list = []
-    for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+    # Creating JSON strings
+    processed_file_list = [
+        template.format(process_file(english), process_file(german))
+        for english, german in zip(english_file_list, german_file_list)
+    ]
     return processed_file_list
-
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
-        for file in file_list:
-            f.write('\n')
-            
+    with open(path, 'w') as file:
+        for line in file_list:
+            file.write(line + '\n')
+
 if __name__ == "__main__":
-    path = './'
     german_path = './german.txt'
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
-    write_file_list(processed_file_list, path+'concated.json')
+    write_file_list(processed_file_list, './concated.json')
+


### PR DESCRIPTION
In the path_to_file_list function, the file is opened in 'w' mode (write mode), which is used for writing new content, not for reading. You need to open the file in read mode.
Correction: Change 'w' to 'r'.
In the path_to_file_list function, the code attempts to return a variable lines which has not been defined or assigned.
Correction: Add code to read the contents of the file and return it as a list.
Function Usage and Logic Error:
The train_file_list_to_json function has incorrectly implemented file processing. Additionally, the JSON string template is improperly structured.
Correction: Correctly structure the JSON template and accurately implement the string processing logic.
Incorrect File Writing Mode:
In the write_file_list function, the file is opened in 'r' mode (read mode), which is not suitable for writing. You need to use 'w' mode (write mode) or 'a' mode (append mode) for writing.
Correction: Change 'r' to 'w'.
Incorrect Function Call:
In the main block, the use of train_file_list_to_json and path_to_file_list functions is incorrect.
Correction: Correct the function calls to ensure they are properly used.