### PR TITLE
correction

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
a1. li = open(path, 'w') -> lines = open(path, 'r').read().split('\n')
b1. 파일을 쓰기 모드로 열고 li가 아닌 lines 변수를 정의해야함

a2. file = file.replace('\\', '\\') -> file = file.replace('\\', '\\\\')
b2. 기존에 replace는 의미가 없음

a3. template_start = '{\"German\":\"' -> template_start = '{\"English\":\"'
b3. English, German 순서로 출력하기 위함임

a4. english_file = process_file(german_file) -> german_file = process_file(german_file)
b4. german_file을 processing한 결과는 german_file에 넣어야 함

a5. processed_file_list.append(template_mid + english_file + template_start + german_file + template_start) -> processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
b5. template 문자열을 순서에 맞게 조정함

a6. with open(path, 'r') as f: -> with open(path, 'w') as f:
b6. f.write하기 위해서는 쓰기 모드로 열어야 함

a7. f.write('\n') -> f.write(file + '\n')
b7. file 내용을 추가 안하면 의미가 없음

a8. german_file_list = train_file_list_to_json(german_path) -> german_file_list = path_to_file_list(german_path)
b8. 적절하지 않은 함수 사용

a9. processed_file_list = path_to_file_list(english_file_list, german_file_list) -> processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
b9. 적절하지 않은 함수 사용

