### PR TITLE
Fix line 6: write mode -> read mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    # li = open(path, 'w') -> change to read mode
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
a. What line of code you changed
line 6
    li = open(path, 'w') ->
    lines = open(path, 'r').read().split('\n')
    
b. Why it is a wrong code
The original code opened the file in write mode ('w'), which truncates the file and does not allow reading.
Since the function is supposed to read lines from the file, it must be opened in read mode ('r').