### PR TITLE
fix: use correct key in template for json output

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 


### PR DESCRIPTION
## Which line of code has been changed

In line 20 of main.py, changed the content of template used in function `train_file_list_to_json`.

## Why it is a wrong code

The desired output looks like below:

```
{"English":"India and Japan prime ministers meet in Tokyo","German":"Die Premierminister Indiens und Japans trafen sich in Tokio."}
{"English":"India's new prime minister, Narendra Modi\\ is meeting his Japanese counterpart, Shinzo Abe, in Tokyo to discuss economic and security ties, on his first major foreign visit since winning May's election.\",","German":"Indiens neuer Premierminister Narendra Modi\\ trifft bei seinem ersten wichtigen Auslandsbesuch seit seinem Wahlsieg im Mai seinen japanischen Amtskollegen Shinzo Abe in Toko, um wirtschaftliche und sicherheitspolitische Beziehungen zu besprechen."}
...
```

Accordingly, the template should look like `{"English":"$1","German":"$2"}`, but the current one is `{"German":"$1","German":"$2"}`. Modify the first key from `German` to `English` to follow the desired output.