### PR TITLE
Fix incorrect file read logic in path_to_file_list function

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
Replaced incorrect line 'li = open(path, 'w')' with 'lines = open(path, 'r').read().split('\n')' in the 'path_to_file_list' function.

- The original line used 'open(path, 'w')', which opens the file in write mode. This immediately erases the file content, making it impossible to read any existing lines.
- It also assigned the result to 'li', which seems like a typo. The return value was not used meaningfully.
- I fixed this by:
  - Opening the file in read mode ('r') to read its contents.
  - Using '.read().split('\n')' to get a list of lines.
  - Assigning the result to a correctly named variable 'lines'.
