### PR TITLE
Fix corrected

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,50 +1,35 @@
 from typing import List
+import json
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = [line.strip() for line in f if line.strip()]
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
-    def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
-        return file
-
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
-
-    # Can this be working?
-    processed_file_list = []
-    for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
-    return processed_file_list
-
+    """Converts two lists of sentences into a list of JSON-formatted strings"""
+    json_lines = []
+    for en, de in zip(english_file_list, german_file_list):
+        json_obj = {"English": en, "German": de}
+        json_str = json.dumps(json_obj, ensure_ascii=False)
+        json_lines.append(json_str)
+    return json_lines
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
-        for file in file_list:
-            f.write('\n')
-            
+    with open(path, 'w', encoding='utf-8') as f:
+        for line in file_list:
+            f.write(line + '\n')
+
 if __name__ == "__main__":
-    path = './'
-    german_path = './german.txt'
     english_path = './english.txt'
+    german_path = './german.txt'
+    output_path = './concated.json'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
-    write_file_list(processed_file_list, path+'concated.json')
+    write_file_list(processed_file_list, output_path)


### PR DESCRIPTION
Line 5: Changed 'w' to 'r' in open(path, 'r'), because 'w' was overwriting the file instead of reading
Line 6: Added lines = [line.strip() for line in f] because lines was undefined
Line 15: Fixed logic because original code was replacing special characters incorrectly and used english_file for both variables
Line 29: Changed 'r' to 'w' in output file write mode because 'r' was incorrect for writing



