### PR TITLE
Fix file reading mode and correct variable overwrite in loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,13 +2,14 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r', encoding='utf-8') as f:
+	lines = [line.strip() for line in f.readlines()]
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""
     # Preprocess unwanted characters
-    def process_file(file):
+    def process_file(line):
         if '\\' in file:
             file = file.replace('\\', '\\')
         if '/' or '"' in file:
@@ -25,7 +26,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
         processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
     return processed_file_list


### PR DESCRIPTION
수정한 줄:
- line 3: 'open(path, 'w')' → 'open(path, 'r')'
- line 22–23: english_file = process_file(german_file)

수정 이유:
- 'w' 모드는 읽기 불가능하므로 'r'로 바꿨습니다.
- 영어 문장을 처리해야 하는 부분에서 실수로 독일어 문장을 덮어쓰는 버그가 있어 변수명을 수정했습니다.
