### PR TITLE
[fix] change read function in path_to_file_list function

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
## a. What line of code you changed
```python
- li = open(path, 'w')
+ lines = open(path, 'r').read().split('\n')
```

## b. Why it is a wrong code
The original code used `'w'` (write) mode, which opens the file for writing and deletes all existing content.  
This is incorrect because the function is supposed to read lines from the file.  
Using `'r'` (read) mode allows the file to be read properly, and splitting by `\n` ensures the result is a list of lines.
