### PR TITLE
Fix: corrected file open mode in path_to_file_list and write_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as f:
+        lines = f.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -33,7 +34,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
             f.write('\n')
             


### PR DESCRIPTION
What I changed
- In path_to_file_list(), changed 'w' to 'r'
- In write_file_list(), changed 'r' to 'w'

Why it is wrong
- 'w' mode deletes file content. 'r' should be used for reading.
- Writing is not possible in 'r' mode. It must be `'w'` for writing.
