### PR TITLE
change str.replace()

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')


### PR DESCRIPTION
Professor, I changed line 13.  
We should replace 2 back slash to 4 back slash
This is because when we use backslashes in Python strings, we need to escape them using an extra backslash.  
Also, when saving the text as JSON, we must escape it once more, resulting in double escaping.  
So we need two extra backslashes.
