### PR TITLE
Fix: Corrected issues in main.py for JSON generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
+            file = file.replace('\\', '\\\\')
+        if '/' in file or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
line 5: li = open(path, 'w') to lines = open(path, 'r').read().split('\n')
The function path_to_file_list(path: str) -> List[str] is intended to return a list of lines from the file. The variable li was used to open the file, but the function signature and its purpose imply that lines (containing the file content) should be returned.
Opening the file with 'w' (write mode) would erase the existing content of the file. To read the file's content, it must be opened with 'r' (read mode).

line 13 (inside process_file function): file = file.replace('\\', '\\') to file = file.replace('\\', '\\\\')
What was wrong: Replacing a backslash ('\\') with a single backslash ('\\') has no effect. To properly escape a backslash for JSON string format, it needs to be replaced with two backslashes ('\\\\').

line 14 (inside process_file function): if '/' or '"' in file: to if '/' in file or '"' in file:
The condition if '/' or '"' in file: would always evaluate to True because the non-empty string '/' is truthy. The correct logic to check if either '/' or '"' is in the file string is if '/' in file or '"' in file:.

line 20 (JSON template): template_start = '{\"German\":\"' to template_start = '{\"English\":\"'
The template_start was meant for the English text, but its key was incorrectly set to "German". It should be "English" for the English part of the JSON object.

line 28 (in the loop): english_file = process_file(german_file) to german_file = process_file(german_file)
The result of process_file(german_file) (the processed German text) was assigned back to english_file. This overwrote the previously processed English text stored in english_file, losing the English content for that pair.

line 30 (in the loop): processed_file_list.append(template_mid + english_file + template_start + german_file + template_start) to processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
The order of concatenation for template_start, template_mid, template_end, and the processed english_file and german_file strings was incorrect. This resulted in a malformed string that did not represent the intended JSON structure: {"English":"english_text","German":"german_text"}.

line 36: with open(path, 'r') as f: to with open(path, 'w') as f:
The output file was opened in 'r' (read mode). To write content to the file, it must be opened in 'w' (write mode) or 'a' (append mode).

line 38: f.write('\n') to f.write(file + '\n')
For each item in file_list, only a newline character ('\n') was written to the file. The actual string content (the file variable, which should be a JSON string) was not being written.

line 46: german_file_list = train_file_list_to_json(german_path) to german_file_list = path_to_file_list(german_path)
The german_path (a string) was passed to train_file_list_to_json. This function expects two lists of strings as arguments, not a single file path. To read the lines from german.txt, path_to_file_list(german_path) should have been used.

line 48: processed_file_list = path_to_file_list(english_file_list, german_file_list) to processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
The english_file_list and german_file_list (two lists of strings) were passed to path_to_file_list. This function expects a single file path (a string) as an argument. To convert these lists into JSON strings, train_file_list_to_json(english_file_list, german_file_list) should have been used.