### PR TITLE
corrected logic in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
-
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
+    
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
I fixed line 5, line 13, line 20, line 28, line 30, line 36, line 38, line 46, line 48.
line 5 : variable "li" is not used. we should change name to "lines". and, we should 'read' the file, not 'write'. so, we should change the open type('w'->'r').
line 13: to make '\\' in python, we should use '\\\\', not '\\'.
line 20: to correct the output with assignment requires, we should change the variable template_start with string '{\"English\":\"' .
line 28: in original code, variable english_file takes german_files. So we should change this name to german_files.
line 30: to correct the output with assignment requires, we should change the order of variables, and we should use the variable template_end.
line 36: Since we should write the file in line 36, the open type should be 'w'. So we should change the open type('r' -> 'w').
line 38: if we write only '\n', nothing will written. so we should write file + '\n'.
line 46: german_file_list must get a list of lines in file, so the function should changed into path_to_file_list(german_file).
line 48: processed_file_list must convert two lists of file paths into a list of json strings, so the function should changed into train_file_list_to_json.