### PR TITLE
Fix: path_to_file_list 함수의 파일 열기 모드 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as f:
+        lines = f.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
기존 코드에서는 path_to_file_list 함수에서 파일을 'w' 모드로 열고 있었습니다. 하지만 이 함수는 파일 내용을 읽어 리스트로 반환하는 역할을 해야 하는데,
'w' 모드로 열게 되면 파일이 쓰기 전용으로 열리면서 내용이 모두 삭제되는 문제가 발생합니다.

이로 인해 이후 과정에서 빈 리스트가 반환되어, 전체 프로그램이 정상적으로 작동하지 않았습니다.

따라서 파일을 'r' 모드로 열 수 있도록 수정하였고,
read().splitlines()를 사용하여 각 줄을 리스트 형태로 저장하도록 구현했습니다.