### PR TITLE
Fix errors in main.py for correct JSON concatenation

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,49 +2,37 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    with open(path, 'r') as f:
+        return f.readlines()
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
+    """Converts two lists of strings into a list of JSON strings"""
     def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
+        file = file.replace('\\', '\\\\').replace('"', '\\"')
         return file
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
-
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        eng = process_file(english_file.strip())
+        ger = process_file(german_file.strip())
+        json_str = f'{{"English":"{eng}","German":"{ger}"}}'
+        processed_file_list.append(json_str)
     return processed_file_list
-
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
-            
+            f.write(file + '\n')
+
 if __name__ == "__main__":
-    path = './'
-    german_path = './german.txt'
     english_path = './english.txt'
+    german_path = './german.txt'
+    output_path = './concated.json'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
-    write_file_list(processed_file_list, path+'concated.json')
+    write_file_list(processed_file_list, output_path)


### PR DESCRIPTION
Modified Code

Line 5: Changed open(path, 'w') to open(path, 'r')
The file was opened in mode 'w', which erased its content. Changed to mode 'r'.

Line 15: Incorrect variable use
Overwriting english_file with German data caused loss of English data. Used separate variables instead.

Line 22: Changed open(path, 'r') to open(path, 'w')
File writing was not possible. Changed to write mode.

Line 31: Corrected function call order
Incorrect function call order led to JSON conversion failure. Corrected the flow.