### PR TITLE
Fix: corrected line pairing and JSON output in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,50 +1,35 @@
+import json
 from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
-    """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    """Reads a file and returns a list of stripped lines"""
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = [line.strip() for line in f if line.strip()]
     return lines
 
-def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
-    def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
-        return file
+def train_file_list_to_json(english_lines: List[str], german_lines: List[str]) -> List[dict]:
+    """Converts two lists of sentences into a list of dictionaries"""
+    result = []
+    for en, de in zip(english_lines, german_lines):
+        result.append({
+            "English": en,
+            "German": de
+        })
+    return result
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
+def write_file_list(json_data: List[dict], path: str) -> None:
+    """Writes a list of dictionaries to a JSON file"""
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(json_data, f, ensure_ascii=False, indent=2)
 
-    # Can this be working?
-    processed_file_list = []
-    for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
-    return processed_file_list
-
-
-def write_file_list(file_list: List[str], path: str) -> None:
-    """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
-        for file in file_list:
-            f.write('\n')
-            
 if __name__ == "__main__":
-    path = './'
-    german_path = './german.txt'
     english_path = './english.txt'
+    german_path = './german.txt'
+    output_path = './concated.json'
 
-    english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    english_lines = path_to_file_list(english_path)
+    german_lines = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_data = train_file_list_to_json(english_lines, german_lines)
 
-    write_file_list(processed_file_list, path+'concated.json')
+    write_file_list(processed_data, output_path)


### PR DESCRIPTION
## What I changed
- Fixed file read mode in `path_to_file_list()` (`'w'` → `'r'`)
- Corrected undefined variable `lines`
- In `train_file_list_to_json()`, avoided overwriting `english_file` with `german_file`
- Used proper JSON formatting: {"English": ..., "German": ...}
- Changed file write mode to `'w'` in `write_file_list()`
- Rewired the `main` block with correct function calls and arguments

## Why I changed it
- Original code had critical bugs:
  - Files were being opened in write mode during reading
  - JSON structure was incorrect and keys were malformed
  - Output file writing attempted in read mode
  - Variable overwriting inside the loop

## Result
- Now `main.py` reads both txt files, formats each line pair correctly, and outputs a clean `concated.json`
