### PR TITLE
✨ [박지환] fix: use r mode instead of w when reading file

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as f:
+        lines = f.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
a. What line of code you changed?
- `open(path, 'w')` → replaced with a proper read operation.

b. Why it is a wrong code
- 'w' mode overwrites the file and doesn’t read anything. The function should read the file, so it must use 'r' instead.