### PR TITLE
2025319224 fix: path_to_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
a. What line of code you changed
I changed line 5

b. Why it is a wrong code
The original code was incorrect because it opened the file in write mode ('w') instead of read mode ('r').
When opening with the 'w' mode, Python overwrite the file from zero.

Since the function path_to_file_list is intended to read data, the original code would have accidentally deleted the contents of the file it was trying to access.