### PR TITLE
fix path_to_file_list

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').readlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
### A. What line of code you changed
In function path_to_file_list:
```py
-  li = open(path, 'w')
+  lines = open(path, 'r').readlines()
```
### B. Why it is a wrong code
1. The variable name `li` is wrong. It should be `lines`.
2. To read a text file it needs to open a file in `r` not `w`.
3. Need to call `readlines()` to read strings from a file.