### PR TITLE
Fix file reading and writing functions in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = [line.rstrip('\n') for line in f]
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -33,9 +34,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
-        for file in file_list:
-            f.write('\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        for line in file_list:
+            f.write(line + '\n')
             
 if __name__ == "__main__":
     path = './'


### PR DESCRIPTION
This PR fixes two incorrect functions in main.py so that the script can properly read english.txt and german.txt and generate the required concated.json output for the assignment.

1. path_to_file_list  
- What line of code I changed

**Original code**

```python
li = open(path, 'w')
return lines
````

**Updated code**

```python
with open(path, 'r', encoding='utf-8') as f:
    lines = [line.rstrip('\n') for line in f]
return lines
```

- Why the original code was wrong
The file was opened in write mode 'w', which clears the file and prevents reading. No lines were actually read from the file. The variable lines was never defined, causing a NameError. As a result, the function could not return the English/German lines needed to build the JSON output.

2. write_file_list
- What line of code I changed

**Original code**

```python
with open(path, 'r') as f:
    for file in file_list:
        f.write('\n')
```

**Updated code**

```python
with open(path, 'w', encoding='utf-8') as f:
    for line in file_list:
        f.write(line + '\n')
```

- Why the original code was wrong
The file was opened in read mode 'r', so nothing could be written to the output file. The loop wrote only newline characters and did not write the actual strings in file_list. Because of this, the expected JSON lines would never appear in concated.json.

With these two fixes, the script now correctly reads both input files and writes the expected JSON lines into `concated.json`, completing the assignment requirements.