### PR TITLE
Fixed main.py: Correct file reading and JSON formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,50 +1,31 @@
+import json
 from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
-    """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    """Reads a file and returns a list of trimmed lines."""
+    with open(path, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
-    def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
-        return file
+    """Converts English/German sentence lists into JSON lines."""
+    json_lines = []
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
-
-    # Can this be working?
-    processed_file_list = []
-    for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
-    return processed_file_list
-
+    for eng, ger in zip(english_file_list, german_file_list):
+        json_obj = {"English": eng, "German": ger}
+        json_lines.append(json.dumps(json_obj, ensure_ascii=False))
+    
+    return json_lines
 
 def write_file_list(file_list: List[str], path: str) -> None:
-    """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
-        for file in file_list:
-            f.write('\n')
-            
+    """Writes each JSON string on its own line."""
+    with open(path, "w", encoding="utf-8") as f:
+        for line in file_list:
+            f.write(line + "\n")
+
 if __name__ == "__main__":
-    path = './'
-    german_path = './german.txt'
-    english_path = './english.txt'
+    english_file_list = path_to_file_list("english.txt")
+    german_file_list = path_to_file_list("german.txt")
 
-    english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
-
-    write_file_list(processed_file_list, path+'concated.json')
+    write_file_list(processed_file_list, "concated.json")


### PR DESCRIPTION
Error 1: Fixed path_to_file_list (lines 4–7)
1. Changed open(path, 'w') → open(path, 'r') because 'w' wipes the file and prevents reading. 
2. Fixed return lines → proper list comprehension.

Error 2: Fixed JSON generation in train_file_list_to_json
1. Removed incorrect conditions like if '/' or '"' in file: which always evaluate to true. 
2. Replaced broken template-based JSON with json.dumps. 
3. Corrected incorrect variable overwrite: english_file = process_file(german_file).

Error 3: Fixed write_file_list (lines 27–31)
1. Changed open(path, 'r') → open(path, 'w') because writing was impossible. 
2. Added actual writing of the content (f.write(line + "\n")).

Error 4: Fixed the main function logic
1. Original code passed wrong arguments to functions and used wrong return values.
2. Replaced with correct calls: