### PR TITLE
Fix variable overwrite bug in train_file_list_to_json

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
         processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
     return processed_file_list


### PR DESCRIPTION
a) Fixed the incorrect assignment `english_file = process_file(german_file)` and
added `german_file = process_file(german_file)` instead.

b) It overwrote the English text with German text, breaking the JSON output.