### PR TITLE
Fix incorrect language key in JSON template

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 


### PR DESCRIPTION
a. Line 20
b. The original code causes a duplicate 'German' key in the concatenated JSON output. It must be changed to 'English' to match the intended format.