### PR TITLE
Fix multiple bugs in main.py

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+﻿MIT License
+
+Copyright (c) 2026 keunhyung
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,32 +10,31 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
+    template_start = '{"English":"'
+    template_mid = '","German":"'
+    template_end = '"}'
 
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +42,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
## Bug Fixes in main.py

### Bug 1 — Line 5: Wrong variable name and file mode in `path_to_file_list`
- **Before:** `li = open(path, 'w')`
- **After:** `lines = open(path, 'r').read().split('\n')`
- **Reason:** Three errors: variable named `li` but `lines` is returned; file opened in write mode `'w'` instead of read mode `'r'`; missing `.read().split('\n')` to convert file content to a list.

### Bug 2 — Line 13: No-op replace in `process_file`
- **Before:** `file.replace('\\', '\\')`
- **After:** `file.replace('\\', '\\\\')`
- **Reason:** Replacing `\` with `\` does nothing. Must escape backslash to `\\` for valid JSON output.

### Bug 3 — Line 20: Wrong key name in `template_start`
- **Before:** `template_start = '{"German":"'`
- **After:** `template_start = '{"English":"'`
- **Reason:** The first key in each JSON entry must be `"English"`, not `"German"`.

### Bug 4 — Line 28: German value assigned to English variable
- **Before:** `english_file = process_file(german_file)`
- **After:** `german_file = process_file(german_file)`
- **Reason:** The processed german value was overwriting the english variable, causing both fields to contain the german text.

### Bug 5 — Line 30: Wrong template order in `append`
- **Before:** `template_mid + english_file + template_start + german_file + template_start`
- **After:** `template_start + english_file + template_mid + german_file + template_end`
- **Reason:** The JSON structure must be `template_start → English → template_mid → German → template_end`. The original order was completely reversed and used wrong template variables.

### Bug 6 — Line 36: File opened in read mode in `write_file_list`
- **Before:** `open(path, 'r')`
- **After:** `open(path, 'w')`
- **Reason:** Cannot write to a file opened in read mode `'r'`. Must use write mode `'w'`.

### Bug 7 — Line 38: Content not written in `write_file_list`
- **Before:** `f.write('\n')`
- **After:** `f.write(file + '\n')`
- **Reason:** Only a newline was written instead of the actual file content.

### Bug 8 — Line 46: Wrong function called for german_file_list
- **Before:** `german_file_list = train_file_list_to_json(german_path)`
- **After:** `german_file_list = path_to_file_list(german_path)`
- **Reason:** `train_file_list_to_json` requires two list arguments, not a path string. `path_to_file_list` should be used here.

### Bug 9 — Line 48: Wrong function called for processed_file_list
- **Before:** `processed_file_list = path_to_file_list(english_file_list, german_file_list)`
- **After:** `processed_file_list = train_file_list_to_json(english_file_list, german_file_list)`
- **Reason:** `path_to_file_list` takes a single path string, not two lists. `train_file_list_to_json` is the correct function to convert the two lists into JSON format.