### PR TITLE
Fix path_to_file_list feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
In function `path_to_file_list` i changed:
`li = open(path, 'w')` to `lines = open(path, 'r')`.

The function `path_to_file_list` is meant to be in reading mode,`r`, but the mode is currently in writing mode,`w`. Also, the function returns `return lines`, but the variable is declared as `li`. So change the return variable name to `lines`.
