### PR TITLE
fix main.py errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,9 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r', encoding='utf-8') as f:  #수정1
+        lines = [line.strip() for line in f.readlines()]  #수정2
+
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +12,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
+            file = file.replace('\\', '\\\\')  #수정3
+        if '/' in file or '"' in file:  #수정4
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'  #수정5
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +27,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)  #수정6
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)  #수정7
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w', encoding='utf-8') as f:  #수정8
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')  #수정9
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +45,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)  #수정10
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)  #수정11
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
I fixed several errors in main.py.

#수정1
I changed open(path, 'w') to open(path, 'r', encoding='utf-8') in path_to_file_list.
The original code was wrong because this function should read english.txt and german.txt. Write mode ('w') can erase the file contents.

#수정2
I changed f.readlines() to [line.strip() for line in f.readlines()].
The original code kept newline characters, so I removed them to make each line clean before converting it to JSON.

#수정3
I changed file.replace('\\', '\\') to file.replace('\\', '\\\\').
The original code did not actually escape backslashes correctly.

#수정4
I changed if '/' or '"' in file to if '/' in file or '"' in file.
The original condition was logically wrong because '/' is always treated as True.

#수정5
I changed template_start from {"German":" to {"English":".
The original template was wrong because the first key should be English, not German.

#수정6
I changed english_file = process_file(german_file) to german_file = process_file(german_file).
The original code overwrote english_file with the German line, so the English text was lost.

#수정7
I fixed the append line to combine template_start, english_file, template_mid, german_file, and template_end in the correct order.
The original code created an invalid JSON string.

#수정8
I changed open(path, 'r') to open(path, 'w', encoding='utf-8') in write_file_list.
The original code was wrong because this function should create and write concated.json, not read it.

#수정9
I changed f.write('\n') to f.write(file + '\n').
The original code only wrote blank lines instead of writing the processed JSON strings.

#수정10
I changed german_file_list = train_file_list_to_json(german_path) to german_file_list = path_to_file_list(german_path).
The original code was wrong because german.txt should be read first before converting the English and German lists to JSON.

#수정11
I changed processed_file_list = path_to_file_list(english_file_list, german_file_list) to processed_file_list = train_file_list_to_json(english_file_list, german_file_list).
The original code called the wrong function. path_to_file_list only reads one file path, while train_file_list_to_json converts the two lists into JSON strings.