### PR TITLE
Fix variable overwrite bug in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
         processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
     return processed_file_list


### PR DESCRIPTION
Before:
english_file = process_file(german_file)

After:
german_file = process_file(german_file)

Reason:
The original code overwrote english_file with the processed German sentence.
Because of this, the English sentence was lost, so the English/German pair could not be generated correctly.