### PR TITLE
Fix main.py bugs

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,9 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    li = open(path, 'r', encoding='utf-8')
+    lines = li.read().splitlines()
+    li.close()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +12,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
+            file = file.replace('\\', '\\\\')
+        if '/' in file or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +27,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +45,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
a. What line of code I changed

line 5-7: changed file open from write mode to read mode, then read lines by `splitlines()` and close file.
line 15-16: fixed backslash escaping and fixed slash/quote condition.
line 22, 30, 32: fixed JSON format, English/German order, and wrong variable.
line 38-40: changed output file to write mode and write each json line.
line 48-50: fixed function calls, so txt files become lists first.

b. Why it is a wrong code

line 5-7: original `w` mode can empty input file, and `lines` was returned before it was made.
line 15-16: original backslash replace does nothing, and `if '/' or ...` is always true.
line 22, 30, 32: original code makes wrong JSON because key, order, and variable are mixed.
line 38-40: original code opens output as read only and writes only blank lines.
line 48-50: original code passes wrong type of values to the functions, so script cannot run.