### PR TITLE
Fix bugs in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,50 +1,49 @@
 from typing import List
 
+
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.read().split('\n')
+    if lines and lines[-1] == '':
+        lines = lines[:-1]
     return lines
+
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
+            file = file.replace('\\', '\\\\')
+        if '/' in file or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
-    # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        german_file = process_file(german_file)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         for file in file_list:
-            f.write('\n')
-            
+            f.write(file + '\n')
+
+
 if __name__ == "__main__":
     path = './'
     german_path = './german.txt'
     english_path = './english.txt'
-
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
-
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
-
-    write_file_list(processed_file_list, path+'concated.json')
+    german_file_list = path_to_file_list(german_path)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
+    write_file_list(processed_file_list, path + 'concated.json')


### PR DESCRIPTION
Hello @agwaBom, I found several bugs in main.py and fixed them.

1. Line 5 — `open(path, 'w')` → `open(path, 'r')`
   'w' mode truncates the file. Since `path_to_file_list` should READ
   the file, it must be opened in 'r' mode. Also, the original code
   had `return lines` but `lines` was never defined.

2. Line 13 — `file.replace('\\', '\\')` → `file.replace('\\', '\\\\')`
   Replacing a single backslash with a single backslash is a no-op.
   To properly escape backslashes for JSON, '\' should become '\\'.

3. Line 14 — `if '/' or '"' in file:` → `if '/' in file or '"' in file:`
   Operator precedence made the original always True because '/' is truthy.

4. Line 20 — `'{"German":"'` → `'{"English":"'`
   The starting template should use the "English" key.

5. Line 28 — `english_file = process_file(german_file)` → `german_file = process_file(german_file)`
   The original overwrote the processed english_file with German content.

6. Line 29 — Wrong template order. Corrected to
   `template_start + english + template_mid + german + template_end`.

7. Line 34 — `open(path, 'r')` → `open(path, 'w')`
   write_file_list is supposed to write, not read.

8. Line 36 — `f.write('\n')` → `f.write(file + '\n')`
   The original only wrote a newline.

9. Line 43 — `train_file_list_to_json(german_path)` → `path_to_file_list(german_path)`
   Wrong function call.

10. Line 44 — `path_to_file_list(...)` → `train_file_list_to_json(...)`
    Wrong function call.