### PR TITLE
Fix main.py file conversion logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,50 +1,50 @@
 from typing import List
+import json
+
 
 def path_to_file_list(path: str) -> List[str]:
-    """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    """Reads a file and returns a list of lines in the file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return [line.rstrip("\n") for line in f]
 
-def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
-    def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
-        return file
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
-
-    # Can this be working?
+def train_file_list_to_json(
+    english_file_list: List[str],
+    german_file_list: List[str]
+) -> List[str]:
+    """Converts English and German lines into JSON strings."""
     processed_file_list = []
-    for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+    for english_file, german_file in zip(english_file_list, german_file_list):
+        json_line = json.dumps(
+            {
+                "English": english_file,
+                "German": german_file
+            },
+            ensure_ascii=False
+        )
+        processed_file_list.append(json_line)
+
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
-    """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    """Writes a list of strings to a file, each string on a new line."""
+    with open(path, "w", encoding="utf-8") as f:
         for file in file_list:
-            f.write('\n')
-            
+            f.write(file + "\n")
+
+
 if __name__ == "__main__":
-    path = './'
-    german_path = './german.txt'
-    english_path = './english.txt'
+    german_path = "./german.txt"
+    english_path = "./english.txt"
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(
+        english_file_list,
+        german_file_list
+    )
 
-    write_file_list(processed_file_list, path+'concated.json')
+    write_file_list(processed_file_list, "./concated.json")


### PR DESCRIPTION
I changed main.py to fix the file reading, JSON conversion, and file writing logic.

Changed code:
- path_to_file_list()
- train_file_list_to_json()
- write_file_list()
- __main__ block

Why the original code was wrong:
- path_to_file_list opened the input file with 'w' mode, which can erase the file instead of reading it.
- It returned an undefined variable named lines.
- train_file_list_to_json used incorrect JSON formatting logic.
- write_file_list opened the output file with 'r' mode, so it could not write the result.
- In the __main__ block, the functions were called in the wrong order.