### PR TITLE
Fix logic to correctly match and format JSON data

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,50 +1,23 @@
-from typing import List
+import json
 
-def path_to_file_list(path: str) -> List[str]:
-    """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+def main():
+    with open('english.txt', 'r', encoding='utf-8') as eng_file:
+        eng_lines = eng_file.readlines()
+        
+    with open('german.txt', 'r', encoding='utf-8') as ger_file:
+        ger_lines = ger_file.readlines()
 
-def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
-    def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
-        return file
+    result = []
+    
+    for eng, ger in zip(eng_lines, ger_lines):
+        result.append({
+            "English": eng.strip(),
+            "German": ger.strip()
+        })
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
+    with open('concated.json', 'w', encoding='utf-8') as json_file:
+        for item in result:
+            json_file.write(json.dumps(item) + '\n')
 
-    # Can this be working?
-    processed_file_list = []
-    for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
-    return processed_file_list
-
-
-def write_file_list(file_list: List[str], path: str) -> None:
-    """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
-        for file in file_list:
-            f.write('\n')
-            
 if __name__ == "__main__":
-    path = './'
-    german_path = './german.txt'
-    english_path = './english.txt'
-
-    english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
-
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
-
-    write_file_list(processed_file_list, path+'concated.json')
+    main()


### PR DESCRIPTION
기존 `main.py`의 텍스트 병합 및 JSON 저장 로직을 수정

반복문> 텍스트 파일의 줄을 읽어와서 합치는 부분
결과를 concated.json 파일로 저장하는 부분

기존 코드는 두 파일의 문장을 매칭 못했거나, \n를 처리하지 않아 JSON 출력 결과가 과제 명세서의 형태처럼 깔끔하게 나오지 않고 깨졌는데 zip()  사용하여 두 텍스트의 줄을 짝지었고, strip()을 사용해 불필요한 줄바꿈 문자를 제거함. 또한 json.dumps()로 딕셔너리를 올바른 JSON 문자열로 변환하여 파일에 쓰도록 바꿈