### PR TITLE
Fix multiple bugs in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,41 +11,34 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
+            file = file.replace('\\', '\\\\')
+        if '/' in file or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
-
     # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
-
-    # Can this be working?
+    template_start = '{"English":"'
+    template_mid = '","German":"'
+    template_end = '"}'
+    
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        german_file = process_file(german_file)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
-
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
     german_path = './german.txt'
     english_path = './english.txt'
-
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
-
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
-
+    german_file_list = path_to_file_list(german_path)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
     write_file_list(processed_file_list, path+'concated.json')

--- a/main.py
+++ b/main.py
@@ -2,13 +2,13 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    with open(path, 'r', encoding='utf-8') as f:
-        lines = f.read().splitlines()
+    with open(path, 'r', encoding='utf-8') as li:
+        lines = li.readlines()
+    lines = [line.strip() for line in lines if line.strip()]
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
             file = file.replace('\\', '\\\\')
@@ -16,29 +16,34 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
-    # Template for json file
-    template_start = '{"English":"'
-    template_mid = '","German":"'
-    template_end = '"}'
-    
+
+    template_start = '{\"English\":\"'
+    template_mid = '\",\"German\":\"'
+    template_end = '\"}'
+
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
         german_file = process_file(german_file)
+
         processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
+
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
     with open(path, 'w', encoding='utf-8') as f:
         for file in file_list:
             f.write(file + '\n')
-            
+
 if __name__ == "__main__":
     path = './'
     german_path = './german.txt'
     english_path = './english.txt'
+
     english_file_list = path_to_file_list(english_path)
     german_file_list = path_to_file_list(german_path)
+
     processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
+
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
What I changed and why:

- Line 5: open(path, 'w') → open(path, 'r') — 'w'(쓰기) 모드로는 파일을 읽을 수 없음
- Line 6: return lines → lines = li.readlines() 추가 — lines 변수가 정의되지 않아 NameError 발생
- Line 11: replace('\\', '\\') → replace('\\', '\\\\') — 같은 값으로 교체하면 아무 효과 없음
- Line 12: if '/' or '"' in file → if '/' in file or '"' in file — '/'는 항상 truthy라 조건이 항상 True
- Line 18: template_start = '{"German":"' → '{"English":"' — 시작 키가 English여야 함
- Line 26: english_file = process_file(german_file) → german_file = process_file(german_file) — english 변수를 german 값으로 덮어씀
- Line 28: 템플릿 순서와 변수가 잘못됨 → template_start + english_file + template_mid + german_file + template_end
- Line 33: open(path, 'r') → open(path, 'w') — 'r'(읽기) 모드로는 파일에 쓸 수 없음
- Line 35: f.write('\n') → f.write(file + '\n') — 줄바꿈만 쓰고 실제 내용을 쓰지 않음
- Lines 41-42: 함수 호출이 뒤바뀜 — path_to_file_list와 train_file_list_to_json 위치가 서로 바뀌어 있었음