### PR TITLE
bug fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,32 +10,32 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
+            file = file.replace('\\', '\\\\')
+        if '/' in file or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
+    template_start = '{"English":"'
+    template_mid = '","German":"'
+    template_end = '"}'
 
     # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    lines = open(path, 'r').read().split('\n')
+    lines = open(path, 'r').read().strip().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
a. What line of code you changed & b. Why it is a wrong code

In path_to_file_list function
Changed from:
li = open(path, 'w')
return lines
to:
lines = open(path, 'r').read().strip().split('\n')
return lines
Reason: The original code opened the file in write mode ('w') instead of read mode ('r'), assigned the file object to an unused variable li, and attempted to return an undefined variable lines. It completely failed to read the file contents. Additionally, .strip() was added to remove trailing newlines from the input files, preventing an empty JSON object from being generated at the end of the file.

In process_file nested function
Changed from:
if '\' in file:
file = file.replace('\', '\')
if '/' or '"' in file:
to:
if '\' in file:
file = file.replace('\', '\\')
if '/' in file or '"' in file:
Reason: The original backslash replacement did not correctly escape the backslash in Python string literals. Additionally, the condition if '/' or '"' in file: is a logical error because '/' evaluates to True unconditionally, causing the replacement block to execute on every string regardless of its contents.

In JSON templates of train_file_list_to_json
Changed from:
template_start = '{"German":"'
template_mid = '","German":"'
template_end = '"}'
to:
template_start = '{"English":"'
template_mid = '","German":"'
template_end = '"}'
Reason: The original template duplicated the "German" key name, missing the mandatory "English" key necessary to construct the correct key-value structure for the final output.

In for loop of train_file_list_to_json
Changed from:
english_file = process_file(german_file)
processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
to:
german_file = process_file(german_file)
processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
Reason: The original line incorrectly overwrote english_file with the processed german_file. Furthermore, the string concatenation sequence inside the append method was completely scrambled and failed to produce a valid JSON format.

In write_file_list function
Changed from:
with open(path, 'r') as f:
for file in file_list:
f.write('\n')
to:
with open(path, 'w') as f:
for file in file_list:
f.write(file + '\n')
Reason: The original code opened the target file in read-only mode ('r'), which triggers an UnsupportedOperation: not writable error when attempting to call .write(). It also completely omitted writing the actual string values from file_list, writing only newline characters.

In main block
Changed from:
german_file_list = train_file_list_to_json(german_path)
processed_file_list = path_to_file_list(english_file_list, german_file_list)
to:
german_file_list = path_to_file_list(german_path)
processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
Reason: The function names and their corresponding arguments were mismatched. train_file_list_to_json was incorrectly invoked with a single path string instead of reading the file lines first, and path_to_file_list was wrongly given parsed lists instead of a path string.