### PR TITLE
Fix bugs in main.py

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 shema8
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
+            file = file.replace('\\', '\\\\')
+        if '/' in file or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,7 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
-
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
-
+    german_file_list = path_to_file_list(german_path)
+    
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
I fixed the following bugs in main.py:
Line 5: li = open(path, 'w') → lines = open(path, 'r').read().splitlines()
Variable name was li instead of lines, causing NameError. Also, the file was opened in write mode ('w') instead of read mode ('r').

Line 13: file.replace('\\', '\\') → file.replace('\\', '\\\\')
Backslash was replaced with itself, so no actual escaping occurred. It should be escaped to \\ in JSON format.

Line 20: '{\"German\":\"' → '{\"English\":\"'
The first key in the JSON template was incorrectly set to German instead of English.

Line 14: if '/' or '"' in file: → if '/' in file or '"' in file:
Incorrect conditional expression. The original always evaluated to True due to Python operator precedence.

Line 28: english_file = process_file(german_file) → german_file = process_file(german_file)
english_file was being overwritten with the processed german_file value.

Line 30: Wrong template order and usage → template_start + english_file + template_mid + german_file + template_end
The template variables were combined in the wrong order, producing invalid JSON output.

Line 36: open(path, 'r') → open(path, 'w')
File was opened in read mode ('r'), making it impossible to write output.

Line 38: f.write('\n') → f.write(file + '\n')
Only a newline was written instead of the actual content.

Line 46-50: train_file_list_to_json(german_path) and path_to_file_list(english_file_list, german_file_list) → functions were called with wrong arguments and swapped.