### PR TITLE
Fix multiple bugs in main.py

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Elarge2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/main.py
+++ b/main.py
@@ -1,50 +1,27 @@
 from typing import List
+import json
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
+    lines = [line for line in lines if line.strip() != '']
     return lines
 
-def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
-    def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
-        return file
+def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]):
+    """Reads english and german file lists and returns a list of json objects"""
+    json_list = []
+    for eng, ger in zip(english_file_list, german_file_list):
+        json_list.append({"English": eng, "German": ger})
+    return json_list
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
+def save_json(json_list, path: str):
+    """Saves a list of json objects to a file"""
+    with open(path, 'w') as f:
+        for json_object in json_list:
+            f.write(json.dumps(json_object, ensure_ascii=False) + '\n')
 
-    # Can this be working?
-    processed_file_list = []
-    for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
-
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
-    return processed_file_list
-
-
-def write_file_list(file_list: List[str], path: str) -> None:
-    """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
-        for file in file_list:
-            f.write('\n')
-            
-if __name__ == "__main__":
-    path = './'
-    german_path = './german.txt'
-    english_path = './english.txt'
-
-    english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
-
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
-
-    write_file_list(processed_file_list, path+'concated.json')
+if __name__ == '__main__':
+    english_file_list = path_to_file_list('english.txt')
+    german_file_list = path_to_file_list('german.txt')
+    json_list = train_file_list_to_json(english_file_list, german_file_list)
+    save_json(json_list, 'concated.json')


### PR DESCRIPTION
여러 버그를 수정했습니다.

1. path_to_file_list(): open(path, 'w')로 쓰기 모드로 열고 있었고, split('\n') 없이 문자열 전체를 반환해서 List[str] 타입이 아니었습니다. 또한 li로 받아놓고 lines를 반환하는 변수명 오류도 있었습니다.

2. train_file_list_to_json(): "English" 키 없이 "German" 키가 두 번 사용되었고, english_file에 german_file 값을 덮어쓰는 오류도 있었습니다. json.dumps() 방식으로 수정했습니다.

3. write_file_list(): open(path, 'r') 읽기 모드로 열어서 쓰기가 불가능했고, f.write('\n')으로 내용 없이 줄바꿈만 저장하고 있었습니다.